### PR TITLE
Fix InjectResponse Header

### DIFF
--- a/backend/apps/apiboss/lib/apiregistry_extensions/apibossheaderinjector.js
+++ b/backend/apps/apiboss/lib/apiregistry_extensions/apibossheaderinjector.js
@@ -8,7 +8,7 @@
 function injectResponseHeaders(apiregentry, url, response, requestHeaders, responseHeaders) {
     const headersToAdd = response?.headers;
     if (headersToAdd) for (const headerName of Object.keys(headersToAdd)) responseHeaders[headerName] = headersToAdd[headerName];
-    if (response.data.result) APIREGISTRY.getExtension("jwttokenmanager").injectResponseHeadersInternal(apiregentry, url, response, requestHeaders, responseHeaders);
+    if (response.data.result) APIREGISTRY.getExtension("jwttokenmanager").injectResponseHeaders(apiregentry, url, response, requestHeaders, responseHeaders);
 }
 
 module.exports = {injectResponseHeaders};


### PR DESCRIPTION
- If the APIBoss APIs return true, the injectResponseHeaders function will call the injectResponseHeadersInternal function of jwttokenmanager. However, if the apiregentry does not have the addToken parameter, an error will be thrown. 

- To handle this, we modified the code to call the injectResponseHeaders function of jwttokenmanager instead. This modified function first checks if the apiregentry has the addToken parameter, and if it does, it calls the injectResponseHeadersInternal function.